### PR TITLE
Fix clock to disappear when dragged out of the window

### DIFF
--- a/Control/DrawClock.cs
+++ b/Control/DrawClock.cs
@@ -52,7 +52,6 @@ namespace Manlaan.Clock.Control
         }
         protected override void OnLeftMouseButtonReleased(MouseEventArgs e) {
             if (Drag) {
-                EnsureLocationIsInBounds();
                 _dragging = false;
                 Module._settingClockLoc.Value = this.Location;
             }
@@ -60,23 +59,40 @@ namespace Manlaan.Clock.Control
         }
 
         public void EnsureLocationIsInBounds() {
+            Point windowSize = GameService.Graphics.SpriteScreen.Size;
+
             if(Location.X < 1) {
                 Location = new Point(1, Location.Y);
-            } else if(Location.X + Size.X > Parent.Size.X) {
-                Location = new Point(Parent.Size.X - Size.X, Location.Y);
+            } else if(Location.X + Size.X > windowSize.X) {
+                Location = new Point(windowSize.X - Size.X, Location.Y);
             }
 
             if(Location.Y < 1) {
                 Location = new Point(Location.X, 1);
-            } else if(Location.Y + Size.Y > Parent.Size.Y) {
-                Location = new Point(Location.X, Parent.Size.Y - Size.Y);
+            } else if(Location.Y + Size.Y > windowSize.Y) {
+                Location = new Point(Location.X, windowSize.Y - Size.Y);
             }
+        }
+
+        private Boolean IsPointInBounds(Point point) {
+            Point windowSize = GameService.Graphics.SpriteScreen.Size;
+
+            return point.X > 0 &&
+                    point.Y > 0 &&
+                    point.X < windowSize.X &&
+                    point.Y < windowSize.Y;
         }
 
         public override void UpdateContainer(GameTime gameTime) {
             if (_dragging) {
-                var nOffset = Input.Mouse.Position - _dragStart;
-                Location += nOffset;
+                if(IsPointInBounds(Input.Mouse.Position)) {
+                    var nOffset = Input.Mouse.Position - _dragStart;
+                    Location += nOffset;
+                    EnsureLocationIsInBounds();
+                } else {
+                    _dragging = false;
+                    Module._settingClockLoc.Value = Location;
+                }
 
                 _dragStart = Input.Mouse.Position;
             }

--- a/Control/DrawClock.cs
+++ b/Control/DrawClock.cs
@@ -61,10 +61,15 @@ namespace Manlaan.Clock.Control
 
         public void EnsureLocationIsInBounds() {
             if(Location.X < 1) {
-                Location = new Point(1, this.Location.Y);
+                Location = new Point(1, Location.Y);
+            } else if(Location.X + Size.X > Parent.Size.X) {
+                Location = new Point(Parent.Size.X - Size.X, Location.Y);
             }
+
             if(Location.Y < 1) {
-                Location = new Point(this.Location.X, 1);
+                Location = new Point(Location.X, 1);
+            } else if(Location.Y + Size.Y > Parent.Size.Y) {
+                Location = new Point(Location.X, Parent.Size.Y - Size.Y);
             }
         }
 

--- a/Control/DrawClock.cs
+++ b/Control/DrawClock.cs
@@ -117,7 +117,8 @@ namespace Manlaan.Clock.Control
                 (int)_font.MeasureString(times).Width,
                 (int)_font.MeasureString(times).Height
                 );
-            this.Size = LabelSize + TimeSize;
+            int maxHeight = Math.Max(LabelSize.Y, TimeSize.Y);
+            this.Size = new Point(LabelSize.X + TimeSize.X, maxHeight);
 
             if (!HideLabel) 
                 spriteBatch.DrawStringOnCtrl(this,

--- a/Control/DrawClock.cs
+++ b/Control/DrawClock.cs
@@ -52,10 +52,20 @@ namespace Manlaan.Clock.Control
         }
         protected override void OnLeftMouseButtonReleased(MouseEventArgs e) {
             if (Drag) {
+                EnsureLocationIsInBounds();
                 _dragging = false;
                 Module._settingClockLoc.Value = this.Location;
             }
             base.OnLeftMouseButtonPressed(e);
+        }
+
+        public void EnsureLocationIsInBounds() {
+            if(Location.X < 1) {
+                Location = new Point(1, this.Location.Y);
+            }
+            if(Location.Y < 1) {
+                Location = new Point(this.Location.X, 1);
+            }
         }
 
         public override void UpdateContainer(GameTime gameTime) {

--- a/Module.cs
+++ b/Module.cs
@@ -139,6 +139,7 @@ namespace Manlaan.Clock
         private void UpdateClockSettings_Location(object sender = null, ValueChangedEventArgs<Point> e = null)
         {
             _clockImg.Location = _settingClockLoc.Value;
+            _clockImg.EnsureLocationIsInBounds();
         }
         private DateTime CalcServerTime()
         {

--- a/Module.cs
+++ b/Module.cs
@@ -37,7 +37,9 @@ namespace Manlaan.Clock
         public static SettingEntry<string> _settingClockTimeAlign;
         public static SettingEntry<bool> _settingClockDrag;
         public static SettingEntry<Point> _settingClockLoc;
-        private Control.DrawClock _clockImg; 
+        private Control.DrawClock _clockImg;
+
+        private Point? lastWindowResolution = null;
 
         [ImportingConstructor]
         public Module([Import("ModuleParameters")] ModuleParameters moduleParameters) : base(moduleParameters) { }
@@ -82,7 +84,11 @@ namespace Manlaan.Clock
 
 
             GameService.Graphics.SpriteScreen.Resized += delegate (object sender, ResizedEventArgs args) {
-               _clockImg.EnsureLocationIsInBounds();
+                if(lastWindowResolution != null && GameService.Graphics.Resolution != lastWindowResolution) {
+                   _clockImg.EnsureLocationIsInBounds();
+                }
+
+                lastWindowResolution = GameService.Graphics.Resolution;
             };
         }
 

--- a/Module.cs
+++ b/Module.cs
@@ -79,6 +79,11 @@ namespace Manlaan.Clock
             UpdateClockSettings_Show();
             UpdateClockSettings_Font();
             UpdateClockSettings_Location();
+
+
+            GameService.Graphics.SpriteScreen.Resized += delegate (object sender, ResizedEventArgs args) {
+               _clockImg.EnsureLocationIsInBounds();
+            };
         }
 
         protected override async Task LoadAsync()
@@ -139,7 +144,6 @@ namespace Manlaan.Clock
         private void UpdateClockSettings_Location(object sender = null, ValueChangedEventArgs<Point> e = null)
         {
             _clockImg.Location = _settingClockLoc.Value;
-            _clockImg.EnsureLocationIsInBounds();
         }
         private DateTime CalcServerTime()
         {


### PR DESCRIPTION
# Description
This PR addresses the issue of a disappearing clock in certain cases. In addition to that it adds some improvements and fixes related to the clock placement.

## Steps to reproduce:
1. Open BlishHUD
2. Enable clock dragging
3. Drag clock so the left or top side moves over the display edge
4. Exit BlishHUD
5. Open BlishHUD

## Result:
The clock is invisible

## Reason:
The code doesn't make a bounds check so negative values are saved for the clock position which in turn won't work in the render function.

# Changes/Fixes
- Add bounds check so that the clock can't leave the window
- Add resize check to clock location i.e. move clock back into window bounds if the window is made smaller than the clock location
- Add automatic clock location fix for old versions where the clock config location might be out of window bounds
- Fix calculation of clock height
- Fix clock continues dragging if mouse left window

# TODO

- [x]  Check why the resize event handler is called twice after BlishHUD start without the final window size. Causing the clock-in-window-bounds check to move the clock into a smaller window in some cases.