### PR TITLE
Change clock setting to use relative screen location

### DIFF
--- a/Control/DrawClock.cs
+++ b/Control/DrawClock.cs
@@ -56,12 +56,35 @@ namespace Manlaan.Clock.Control
         protected override void OnLeftMouseButtonReleased(MouseEventArgs e) {
             if (Drag) {
                 _dragging = false;
-                Module._settingClockLoc.Value = this.Location;
+                saveClockLocation();
             }
             base.OnLeftMouseButtonPressed(e);
         }
 
-        public void EnsureLocationIsInBounds() {
+        public void restoreClockLocation() {
+            Point windowSize = GameService.Graphics.SpriteScreen.Size;
+            Vector2 relativeLocation = Module._settingClockLoc.Value;
+            int locationX = (int) (relativeLocation.X * windowSize.X);
+            int locationY = (int) (relativeLocation.Y * windowSize.Y);
+
+            if(locationX == 0)
+                locationX = 1;
+            if(locationY == 0)
+                locationY = 1;
+
+            Location = new Point(locationX, locationY);
+            EnsureLocationIsInBounds();
+        }
+
+        private void saveClockLocation() {
+            EnsureLocationIsInBounds();
+
+            Point windowSize = GameService.Graphics.SpriteScreen.Size;
+            Vector2 relativeLocation = new Vector2((float) Location.X / windowSize.X, (float) Location.Y / windowSize.Y);
+            Module._settingClockLoc.Value = relativeLocation;
+        }
+
+        private void EnsureLocationIsInBounds() {
             Point windowSize = GameService.Graphics.SpriteScreen.Size;
 
             if(Location.X < 1) {
@@ -94,7 +117,7 @@ namespace Manlaan.Clock.Control
                     EnsureLocationIsInBounds();
                 } else {
                     _dragging = false;
-                    Module._settingClockLoc.Value = Location;
+                    saveClockLocation();
                 }
 
                 _dragStart = Input.Mouse.Position;

--- a/Module.cs
+++ b/Module.cs
@@ -38,10 +38,8 @@ namespace Manlaan.Clock
         public static SettingEntry<string> _settingClockLabelAlign;
         public static SettingEntry<string> _settingClockTimeAlign;
         public static SettingEntry<bool> _settingClockDrag;
-        public static SettingEntry<Point> _settingClockLoc;
+        public static SettingEntry<Vector2> _settingClockLoc;
         private Control.DrawClock _clockImg;
-
-        private Point? lastWindowResolution = null;
 
         [ImportingConstructor]
         public Module([Import("ModuleParameters")] ModuleParameters moduleParameters) : base(moduleParameters) { }
@@ -58,7 +56,7 @@ namespace Manlaan.Clock
             _settingClockFontSize = settings.DefineSetting("ClockFont2", "12", "Font Size", "");
             _settingClockLabelAlign = settings.DefineSetting("ClockLebelAlign2", "Right", "Label Align", "");
             _settingClockTimeAlign = settings.DefineSetting("ClockTimeAlign2", "Right", "Time Align", "");
-            _settingClockLoc = settings.DefineSetting("ClockLoc", new Point(100,100), "Location", "");
+            _settingClockLoc = settings.DefineSetting("ClockLoc", new Vector2(0.25f, 0.25f), "Location", "");
             _settingClockDrag = settings.DefineSetting("ClockDrag", false, "Enable Dragging", "");
 
             _settingClockDrag.SettingChanged += UpdateClockSettings_Show;
@@ -88,11 +86,7 @@ namespace Manlaan.Clock
 
 
             GameService.Graphics.SpriteScreen.Resized += delegate (object sender, ResizedEventArgs args) {
-                if(lastWindowResolution != null && GameService.Graphics.Resolution != lastWindowResolution) {
-                   _clockImg.EnsureLocationIsInBounds();
-                }
-
-                lastWindowResolution = GameService.Graphics.Resolution;
+                _clockImg.restoreClockLocation();
             };
         }
 
@@ -154,9 +148,9 @@ namespace Manlaan.Clock
             _clockImg.LabelAlign = (HorizontalAlignment) Enum.Parse(typeof(HorizontalAlignment), _settingClockLabelAlign.Value);
             _clockImg.TimeAlign = (HorizontalAlignment)Enum.Parse(typeof(HorizontalAlignment), _settingClockTimeAlign.Value);
         }
-        private void UpdateClockSettings_Location(object sender = null, ValueChangedEventArgs<Point> e = null)
+        private void UpdateClockSettings_Location(object sender = null, ValueChangedEventArgs<Vector2> e = null)
         {
-            _clockImg.Location = _settingClockLoc.Value;
+            _clockImg.restoreClockLocation();
         }
         private DateTime CalcServerTime()
         {


### PR DESCRIPTION
## Description
This PR changes the clock setting to use a relative screen location.

The change from an absolute to a relative screen location should cause the clock to always be at the same relative window location regardless of its size.

If the window gets too small and the clock would be no longer fully visible it is moved back into the window bounds. In case the window size is increased at a later point in time the clock will return to its  original location.

## Reason
It will fix the following bug:
> in v1.2 of the Clock mod the position always resets to the top left corner after minimizing the game
>\- [xlr on Discord](https://discord.com/channels/531175899588984842/534492173362528287/953242434870075422)

The cause for this bug is that there is currently no reliable way to get accurate resize events about the gw2 window. Currently the resize event of the `GameService.Graphics.SpriteScreen` is used. Minimizing the window causes a resize event of the SpriteScreen with a very small size that moved the clock to the top left corner. With a relative screen location this still happens but as soon as the window gets larger again the clock is moved back.
